### PR TITLE
ci: disable tests for 1.18.X due to the number of goroutines limit (8128)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        version: [1.18.8, 1.19.3]
+        version:
+          - 1.19.3
 
     steps:
       - uses: actions/checkout@v3.1.0


### PR DESCRIPTION
Before 1.19, the max number of goroutines that the race detector could handle was limited to 8128. 
Currently, tests for 1.18.X sometimes failed due to this limitation:

```
race: limit on 8128 simultaneously alive goroutines is exceeded, dying
```

Exceeding this limit during tests is crucial for `gopubsub`. Therefore, this PR drops tests for 1.18 on CI.

Ref: https://go-review.googlesource.com/c/go/+/333529